### PR TITLE
edit imports

### DIFF
--- a/keystone/baseline.py
+++ b/keystone/baseline.py
@@ -118,13 +118,13 @@ import gbtpipe.Baseline as baseline
 # 	clip_cube = cube[clip_lr[0]:-clip_lr[1], :, :]
 # 	clip_cube.write(file_in.replace('.fits','_clip.fits', overwrite=True))
 
-# def mad1d(x):
-#     med0 = np.median(x)
-#     return np.median(np.abs(x - med0)) * 1.4826
+def mad1d(x):
+     med0 = np.median(x)
+     return np.median(np.abs(x - med0)) * 1.4826
 
 
-# def legendreLoss(coeffs, y, x, noise):
-#     return (y - legendre.legval(x, coeffs)) / noise
+def legendreLoss(coeffs, y, x, noise):
+     return (y - legendre.legval(x, coeffs)) / noise
 
 
 # def robustBaseline(y, baselineIndex, blorder=1, noiserms=None):
@@ -137,7 +137,7 @@ import gbtpipe.Baseline as baseline
 #                loss='arctan')
 
 #     return y - legendre.legval(x, opts.x)
->>>>>>> upstream/master
+#>>>>>>> upstream/master
 
 
 def rebaseline(filename, blorder=3, 

--- a/keystone/gridder.py
+++ b/keystone/gridder.py
@@ -17,6 +17,7 @@ import gbtpipe
 from .utils import VlsrByCoord
 from . import __version__
 from .postprocess import *
+import postprocess
 
 
 def baselineSpectrum(spectrum, order=1, baselineIndex=()):
@@ -171,14 +172,31 @@ def gridall(region='NGC7538', **kwargs):
               'H2O', 'HC5N_8_7', 'HC5N_9_8', 'HC7N_19_18',
               'HNCO_1_0']
     griddata(region = region, dirname = region + '_NH3_11',
-             outdir = './images/', rebase=True,
+             outdir = './images/', rebase=False,
              **kwargs)
     templatehdr = fits.getheader('./images/' + region + '_NH3_11_all.fits')
     for thisline in suffix:
         griddata(region = region, dirname = region + '_' + thisline,
-                 outdir = './images/', rebase=True,
+                 outdir = './images/', rebase=False,
                  templateHeader=templatehdr,
                  **kwargs)
+
+def getGainDict():
+    gainDict = {('0', '0') : 0.979128705,
+                ('1', '0') : 0.916095905,
+                ('2', '0') : 0.875017,
+                ('3', '0') : 0.784742095,
+                ('4', '0') : 0.93435506,
+                ('5', '0') : 0.742008405,
+                ('6', '0') : 0.87569747,
+                ('0', '1') : 0.94387634,
+                ('1', '1') : 0.86831252,
+                ('2', '1') : 0.87293043,
+                ('3', '1') : 0.780018805,
+                ('4', '1') : 0.8046946,
+                ('5', '1') : 0.532584695,
+                ('6', '1') : 0.97160044}
+    return(gainDict)
 
 def griddata(pixPerBeam=3.5,
              templateHeader=None,
@@ -192,7 +210,7 @@ def griddata(pixPerBeam=3.5,
              blorder=1,
              Sessions=None,
              file_extension=None,
-             rebase=True, 
+             rebase=False, 
              beamSize=None,
              OnlineDoppler=True,
              flagRMS=True,
@@ -201,8 +219,13 @@ def griddata(pixPerBeam=3.5,
              blankSpike=True,
              rmsThresh=1.5,
              plotTimeSeries=True,
+             gainDict=None,
              filelist=[],
              outdir=None, **kwargs):
+
+    # This uses a fixed set of gain dicts.  
+    if gainDict is None:
+        gainDict = getGainDict()
     if outdir is None:
         outdir = os.getcwd()
     
@@ -251,8 +274,8 @@ def griddata(pixPerBeam=3.5,
     # check that every file in the filelist is valid
     # If not then remove it and send warning message
     for file_i in filelist:
-        try:
-            fits.open(file_i)
+        try: 
+           fits.open(file_i)
         except:
             warnings.warn('file {0} is corrupted'.format(file_i))
             filelist.remove(file_i)
@@ -271,7 +294,7 @@ def griddata(pixPerBeam=3.5,
                               VlsrByCoord=VlsrByCoord,
                               plotTimeSeries=plotTimeSeries,
                               blankSpike=blankSpike,
-                              rebase=rebase,
+                              rebase=rebase, gainDict=gainDict,
                               flagSpike=flagSpike, **kwargs)
     # Convolve the beam size up by 10% in size
     #gbtpipe.Gridding.postConvolve(outdir+outname)


### PR DESCRIPTION
Just a few edits here to get things working on my end. Uncommented `mad1d` and `legendreloss` since the `rebaseline_multi` script calls those functions. Also turned off the automatic `rebase` option in the `griddata` function since I am now using `rebaseline_multi` in a separate call. Finally, I had to add a couple `import` calls to keep things from breaking when loading the `keystone` module.